### PR TITLE
Update to pipeline health status

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,7 @@ repos:
     entry: poetry run isort
     language: system
     types: [python]
+    args: ["--profile", "black"]
   - id: mypy
     name: mypy
     entry: poetry run mypy

--- a/api/pipeline.py
+++ b/api/pipeline.py
@@ -17,7 +17,8 @@ router = APIRouter()
 @router.get("/", response_model=Dict[str, PipelineStatus])
 def get_dag_run_status() -> dict:
     """Get status information about the very latest individual pipeline runs"""
-    dag_ids = get_dag_run_list_with_schedules().keys()
+    dag_list = get_dag_run_list_with_schedules()
+    dag_ids = dag_list.keys()
 
     # only get the latest succesfull run
     latest_runs = {
@@ -29,7 +30,11 @@ def get_dag_run_status() -> dict:
         update_run_health(dag_id, run)
 
     return {
-        id: PipelineStatus(last_completed=run.start_date, health=run.health)
+        id: PipelineStatus(
+            last_completed=run.start_date,
+            health=run.health,
+            schedule_interval=dag_list[id],
+        )
         for id, run in latest_runs.items()
     }
 

--- a/api/pipeline.py
+++ b/api/pipeline.py
@@ -1,64 +1,17 @@
-from datetime import datetime
-from enum import Enum
-from os import getenv
 from typing import Dict, List
 
-import requests
-from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel, Field
+from fastapi import APIRouter
+
+from api.utils.airflow import (
+    PipelineRun,
+    PipelineStatus,
+    get_airflow,
+    get_all_dag_dagruns,
+    get_dag_dagruns,
+    update_run_health,
+)
 
 router = APIRouter()
-
-HOST = f"http://{getenv('AIRFLOW_SERVER')}:8080/api/v1"
-AUTH = ("localhost", getenv("WP3API_AIRFLOW_PASS"))
-
-
-class PipelineHealth(Enum):
-    """Traffic light health indicator"""
-
-    RED = "red"  # The pipeline failed to run
-    ORANGE = "orange"  # A task within the run failed
-    GREEN = "green"  # Pipeline and tasks ran successfully
-    UNKNOWN = "unknown"  # Cannot determine health
-
-
-class PipelineStatus(BaseModel):
-    """Pipeline device status parser"""
-
-    last_completed: datetime
-    health: PipelineHealth
-
-
-class PipelineTask(BaseModel):
-    """Task parser"""
-
-    task_id: str
-    state: str
-
-
-class PipelineRun(BaseModel):
-    """Pipeline run status model"""
-
-    start_date: datetime
-    dag_run_id: str
-    state: str
-    health: PipelineHealth = PipelineHealth.UNKNOWN
-    tasks: List[PipelineTask] = Field(default_factory=list)
-
-
-def get_airflow(endpoint: str) -> dict:
-    """Wrap requests for generalised Airflow GET requests"""
-    try:
-        response = requests.get(HOST + endpoint, auth=AUTH)
-    except requests.exceptions.ConnectionError as e:
-        # Airflow server most likely not accessible
-        raise HTTPException(
-            status_code=502, detail="Error with Apache Airflow Connection"
-        ) from e
-
-    response.raise_for_status()
-    result: dict = response.json()
-    return result
 
 
 @router.get("/", response_model=Dict[str, PipelineStatus])
@@ -98,45 +51,3 @@ def get_dag_run_status_historically() -> dict:
             update_run_health(dag_id, run)
 
     return all_runs
-
-
-def get_dag_dagruns(dag_id: str, limit: int = 1, offset: int = 0) -> List[PipelineRun]:
-    """Get dagruns from a particular dag_id"""
-    payload = get_airflow(
-        f"/dags/{dag_id}/dagRuns?order_by=-start_date&limit={limit}&offset={offset}"
-    )["dag_runs"]
-    return [PipelineRun(**p) for p in payload]
-
-
-def get_all_dag_dagruns(dag_id: str) -> List[PipelineRun]:
-    """Get all possible dagruns from a particular dag_id"""
-    runs, offset, steps = [], 0, 100
-
-    while past_runs := get_dag_dagruns(dag_id, limit=steps, offset=offset):
-        runs.extend(past_runs)
-        offset += steps
-
-    return runs
-
-
-def get_dagrun_tasks(dag_id: str, dag_run_id: str) -> List[PipelineTask]:
-    """Get status information about individual pipeline run's tasks"""
-    payload = get_airflow(f"/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances")[
-        "task_instances"
-    ]
-    return [PipelineTask(**p) for p in payload]
-
-
-def update_run_health(dag_id: str, run: PipelineRun) -> None:
-    """Get tasks and determine health of the run"""
-    # NOTE: Modifies the mutable PipelineRun in place
-
-    run.tasks = get_dagrun_tasks(dag_id, run.dag_run_id)
-    # determine pipeline health
-    run.health = (
-        PipelineHealth.RED
-        if "failed" in run.state
-        else PipelineHealth.ORANGE
-        if any(["failed" in t.state for t in run.tasks])
-        else PipelineHealth.GREEN
-    )

--- a/api/pipeline.py
+++ b/api/pipeline.py
@@ -1,6 +1,7 @@
 from datetime import datetime
+from enum import Enum
 from os import getenv
-from typing import Dict
+from typing import Dict, List
 
 import requests
 from fastapi import APIRouter, HTTPException
@@ -12,17 +13,26 @@ HOST = f"http://{getenv('AIRFLOW_SERVER')}:8080/api/v1"
 AUTH = ("localhost", getenv("WP3API_AIRFLOW_PASS"))
 
 
+class PipelineHealth(Enum):
+    """Traffic light health indicator"""
+
+    RED = "red"  # The pipeline failed to run
+    ORANGE = "orange"  # A task within the run failed
+    GREEN = "green"  # Pipeline and tasks ran successfully
+
+
 class PipelineStatus(BaseModel):
     """Pipeline device status parser"""
 
     last_completed: datetime
-    failed_runs_since: int
+    health: PipelineHealth
 
 
 # possible (expected) responses of the API - will be shown in api docs
 responses = {
     200: {
-        "description": "Overview of pipeline runs per device",
+        "description": "Overview of pipeline runs per device. Pipeline health"
+        + f"can be any of: {[k.name for k in PipelineHealth]}",
         "model": Dict[str, PipelineStatus],
     },
     502: {"description": "Internal connection error with IDEAFAST ETL Pipeline"},
@@ -44,32 +54,93 @@ def get_airflow(endpoint: str) -> dict:
     return result
 
 
-def _parse_status(dag_runs: dict) -> dict:
-    """Parse the Airflow API payload for readability"""
-    last_ok = next(
-        (index for (index, d) in enumerate(dag_runs) if d["state"] == "success"), None
-    )
-
-    # count for 'failed' status up to latest success
-    count_bad = len([1 for d in dag_runs[:last_ok] if d["state"] == "failed"])
-
-    return PipelineStatus(
-        last_completed=dag_runs[last_ok]["start_date"] if last_ok is not None else None,
-        failed_runs_since=count_bad,
-    )
-
-
 @router.get("/", responses=responses)
-def status() -> dict:
-    """Get status information about the ETL pipeline"""
-    dag_ids = [d["dag_id"] for d in get_airflow("/dags")["dags"]]
+def get_dag_run_status() -> dict:
+    """Get status information about the very latest individual pipeline runs"""
+    dag_ids = get_dag_run_list()
 
-    result = {
-        id: _parse_status(
-            get_airflow(f"/dags/{id}/dagRuns?limit=50&order_by=-start_date")["dag_runs"]
+    # just focusing on the latest run
+    latest_runs = {id: get_dag_dagruns(id, limit=1)[0] for id in dag_ids}
+
+    for dag_id, run in latest_runs.items():
+        tasks_status = get_dagrun_tasks(dag_id, run["dag_run_id"])
+        latest_runs[dag_id]["tasks"] = tasks_status
+
+        # determine pipeline health
+        latest_runs[dag_id]["health"] = (
+            PipelineHealth.RED
+            if "failed" in run["state"]
+            else PipelineHealth.ORANGE
+            if any(["failed" in t["state"] for t in tasks_status])
+            else PipelineHealth.GREEN
         )
-        for id in dag_ids
-    }
-    # TODO: add scheduled runs status (inc. if retries are set)
 
-    return result
+    return {
+        id: PipelineStatus(last_completed=s["start_date"], health=s["health"])
+        for id, s in latest_runs.items()
+    }
+
+
+@router.get("/list")
+def get_dag_run_list() -> list:
+    """Get the list of pipelines 'names' on the server"""
+    return [d["dag_id"] for d in get_airflow("/dags")["dags"]]
+
+
+@router.get("/history")
+def get_dag_run_status_historically() -> dict:
+    """Get the history of all pipeline runs"""
+    dag_ids = get_dag_run_list()
+
+    # just focusing on the latest run
+    all_runs = {id: get_all_dag_dagruns(id) for id in dag_ids}
+
+    for dag_id, runs in all_runs.items():
+        for index, run in enumerate(runs):
+            tasks_status = get_dagrun_tasks(dag_id, run["dag_run_id"])
+            all_runs[dag_id][index]["tasks"] = tasks_status
+
+            # determine pipeline health
+            all_runs[dag_id][index]["health"] = (
+                PipelineHealth.RED
+                if "failed" in run["state"]
+                else PipelineHealth.ORANGE
+                if any(["failed" in t["state"] for t in tasks_status])
+                else PipelineHealth.GREEN
+            )
+
+    return all_runs
+
+
+def get_dag_dagruns(dag_id: str, limit: int = 10, offset: int = 0) -> List[dict]:
+    """Get dagruns from a particular dag_id"""
+    info_of_interest = ("start_date", "dag_run_id", "state")
+
+    payload = get_airflow(
+        f"/dags/{dag_id}/dagRuns?order_by=-start_date&limit={limit}&offset={offset}"
+    )["dag_runs"]
+
+    return [{k: data[k] for k in info_of_interest} for data in payload]
+
+
+def get_all_dag_dagruns(dag_id: str) -> List:
+    """Get all possible dagruns from a particular dag_id"""
+    runs = []
+    offset, steps = 0, 100
+
+    while past_runs := get_dag_dagruns(dag_id, limit=steps, offset=offset):
+        runs.extend(past_runs)
+        offset += steps
+
+    return runs
+
+
+def get_dagrun_tasks(dag_id: str, dag_run_id: str) -> List[dict]:
+    """Get status information about individual pipeline run's tasks"""
+    info_of_interest = ("task_id", "state")
+
+    payload = get_airflow(f"/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances")[
+        "task_instances"
+    ]
+
+    return [{k: task[k] for k in info_of_interest} for task in payload]

--- a/api/utils/airflow.py
+++ b/api/utils/airflow.py
@@ -1,0 +1,101 @@
+from datetime import datetime
+from enum import Enum
+from os import getenv
+from typing import List
+
+import requests
+from fastapi import HTTPException
+from pydantic import BaseModel, Field
+
+HOST = f"http://{getenv('AIRFLOW_SERVER')}:8080/api/v1"
+AUTH = ("localhost", getenv("WP3API_AIRFLOW_PASS"))
+
+
+class PipelineHealth(Enum):
+    """Traffic light health indicator"""
+
+    RED = "red"  # The pipeline failed to run
+    ORANGE = "orange"  # A task within the run failed
+    GREEN = "green"  # Pipeline and tasks ran successfully
+    UNKNOWN = "unknown"  # Cannot determine health
+
+
+class PipelineStatus(BaseModel):
+    """Pipeline device status parser"""
+
+    last_completed: datetime
+    health: PipelineHealth
+
+
+class PipelineTask(BaseModel):
+    """Task parser"""
+
+    task_id: str
+    state: str
+
+
+class PipelineRun(BaseModel):
+    """Pipeline run status model"""
+
+    start_date: datetime
+    dag_run_id: str
+    state: str
+    health: PipelineHealth = PipelineHealth.UNKNOWN
+    tasks: List[PipelineTask] = Field(default_factory=list)
+
+
+def get_airflow(endpoint: str) -> dict:
+    """Wrap requests for generalised Airflow GET requests"""
+    try:
+        response = requests.get(HOST + endpoint, auth=AUTH)
+    except requests.exceptions.ConnectionError as e:
+        # Airflow server most likely not accessible
+        raise HTTPException(
+            status_code=502, detail="Error with Apache Airflow Connection"
+        ) from e
+
+    response.raise_for_status()
+    result: dict = response.json()
+    return result
+
+
+def get_dag_dagruns(dag_id: str, limit: int = 1, offset: int = 0) -> List[PipelineRun]:
+    """Get dagruns from a particular dag_id"""
+    payload = get_airflow(
+        f"/dags/{dag_id}/dagRuns?order_by=-start_date&limit={limit}&offset={offset}"
+    )["dag_runs"]
+    return [PipelineRun(**p) for p in payload]
+
+
+def get_all_dag_dagruns(dag_id: str) -> List[PipelineRun]:
+    """Get all possible dagruns from a particular dag_id"""
+    runs, offset, steps = [], 0, 100
+
+    while past_runs := get_dag_dagruns(dag_id, limit=steps, offset=offset):
+        runs.extend(past_runs)
+        offset += steps
+
+    return runs
+
+
+def get_dagrun_tasks(dag_id: str, dag_run_id: str) -> List[PipelineTask]:
+    """Get status information about individual pipeline run's tasks"""
+    payload = get_airflow(f"/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances")[
+        "task_instances"
+    ]
+    return [PipelineTask(**p) for p in payload]
+
+
+def update_run_health(dag_id: str, run: PipelineRun) -> None:
+    """Get tasks and determine health of the run"""
+    # NOTE: Modifies the mutable PipelineRun in place
+
+    run.tasks = get_dagrun_tasks(dag_id, run.dag_run_id)
+    # determine pipeline health
+    run.health = (
+        PipelineHealth.RED
+        if "failed" in run.state
+        else PipelineHealth.ORANGE
+        if any(["failed" in t.state for t in run.tasks])
+        else PipelineHealth.GREEN
+    )

--- a/api/utils/airflow.py
+++ b/api/utils/airflow.py
@@ -24,7 +24,7 @@ class PipelineHealth(Enum):
 class PipelineStatus(BaseModel):
     """Pipeline device status parser"""
 
-    last_completed: datetime
+    last_completed: Optional[datetime]
     health: PipelineHealth
     schedule_interval: Optional[str]
 

--- a/api/utils/airflow.py
+++ b/api/utils/airflow.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from enum import Enum
 from os import getenv
-from typing import List
+from typing import List, Optional
 
 import requests
 from fastapi import HTTPException
@@ -37,7 +37,7 @@ class PipelineTask(BaseModel):
 class PipelineRun(BaseModel):
     """Pipeline run status model"""
 
-    start_date: datetime
+    start_date: Optional[datetime]
     dag_run_id: str
     state: str
     health: PipelineHealth = PipelineHealth.UNKNOWN
@@ -59,7 +59,7 @@ def get_airflow(endpoint: str) -> dict:
     return result
 
 
-def get_dag_dagruns(dag_id: str, limit: int = 1, offset: int = 0) -> List[PipelineRun]:
+def get_dag_dagruns(dag_id: str, limit: int = 25, offset: int = 0) -> List[PipelineRun]:
     """Get dagruns from a particular dag_id"""
     payload = get_airflow(
         f"/dags/{dag_id}/dagRuns?order_by=-start_date&limit={limit}&offset={offset}"

--- a/poetry.lock
+++ b/poetry.lock
@@ -200,6 +200,17 @@ tomli = {version = "*", optional = true, markers = "extra == \"toml\""}
 toml = ["tomli"]
 
 [[package]]
+name = "croniter"
+version = "1.2.0"
+description = "croniter provides iteration for datetime object with cron like format"
+category = "main"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.dependencies]
+python-dateutil = "*"
+
+[[package]]
 name = "distlib"
 version = "0.3.4"
 description = "Distribution utilities"
@@ -662,6 +673,17 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "python-dateutil"
+version = "2.8.2"
+description = "Extensions to the standard Python datetime module"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "python-dotenv"
 version = "0.19.2"
 description = "Read key-value pairs from a .env file and set them as environment variables"
@@ -702,7 +724,7 @@ use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
@@ -949,6 +971,10 @@ coverage = [
     {file = "coverage-6.2-cp39-cp39-win_amd64.whl", hash = "sha256:86f2e78b1eff847609b1ca8050c9e1fa3bd44ce755b2ec30e70f2d3ba3844644"},
     {file = "coverage-6.2-pp36.pp37.pp38-none-any.whl", hash = "sha256:5829192582c0ec8ca4a2532407bc14c2f338d9878a10442f5d03804a95fac9de"},
     {file = "coverage-6.2.tar.gz", hash = "sha256:e2cad8093172b7d1595b4ad66f24270808658e11acf43a8f95b41276162eb5b8"},
+]
+croniter = [
+    {file = "croniter-1.2.0-py2.py3-none-any.whl", hash = "sha256:c214aa35c0de6048f2e3eddb6cb7812c99fcb4039f37f559a4b2d62edcb0d157"},
+    {file = "croniter-1.2.0.tar.gz", hash = "sha256:094422f6aeb9ed646714393503fa388afe4f846e110e1997fea5794e2085c2d7"},
 ]
 distlib = [
     {file = "distlib-0.3.4-py2.py3-none-any.whl", hash = "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b"},
@@ -1235,6 +1261,10 @@ pytest = [
 pytest-cov = [
     {file = "pytest-cov-3.0.0.tar.gz", hash = "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470"},
     {file = "pytest_cov-3.0.0-py3-none-any.whl", hash = "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6"},
+]
+python-dateutil = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
 ]
 python-dotenv = [
     {file = "python-dotenv-0.19.2.tar.gz", hash = "sha256:a5de49a31e953b45ff2d2fd434bbc2670e8db5273606c1e737cc6b93eff3655f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ uvicorn = "^0.16.0"
 requests = "^2.27.0"
 pydantic = "^1.9.0"
 pymongo = "^4.0.1"
+croniter = "^1.2.0"
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.16.0"


### PR DESCRIPTION
This (small) PR updates the `GET /status` endpoint, cleaning up code and making the auto-generated documentation more readable.

The status endpoint now focuses on the very last run attempt, and looks at the tasks within to determine if everything went OK.

Main changes are:
- moved logic to utils folder, keeping `pipeline.py` clean
- introduce traffic light indicator (red, orange, green) for pipeline health
- add endpoint to retrieve pipeline health historically
- use `pydantic` BaseModels for API documentation and reusability
- shows next (logically) planned DAG run in the status payload
- 
## Testing
- run the `ideafast/etl` docker containers (from within the `etl` git repository)
- start the WP3 API, by running `poetry run local`
- navigate to `localhost/swagger` and test out the status endpoints within the documentation